### PR TITLE
feat(fonts): migrate to Astro 6 Fonts API

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,13 +1,28 @@
 // @ts-check
 import preact from '@astrojs/preact';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig } from 'astro/config';
+import { defineConfig, fontProviders } from 'astro/config';
 import { imagetools } from 'vite-imagetools';
 import istanbul from 'vite-plugin-istanbul';
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [preact()],
+
+  fonts: [
+    {
+      name: 'Quicksand',
+      provider: fontProviders.google(),
+      cssVariable: '--font-quicksand',
+    },
+    {
+      name: 'Fraunces',
+      provider: fontProviders.google(),
+      cssVariable: '--font-fraunces',
+      weights: ['300', '400', '600'],
+      styles: ['normal', 'italic'],
+    },
+  ],
 
   server: {
     host: true, // listen on all addresses (helps avoid localhost resolution issues on Windows)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbereder.com",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbereder.com",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "hasInstallScript": true,
       "devDependencies": {
         "@astrojs/preact": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbereder.com",
   "type": "module",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/src/components/head.astro
+++ b/src/components/head.astro
@@ -1,11 +1,13 @@
 ---
+import { Font } from 'astro:assets';
+
 interface Props {
   title?: string;
   description?: string;
   canonical?: string;
   keywords?: string;
-  /** Optional Google Fonts stylesheet URL (e.g. Fraunces). Adds preconnect + link in head. */
-  extraFontUrl?: string;
+  /** Optional extra font CSS variable (e.g. '--font-fraunces') to inject a Font component. */
+  extraFontCssVariable?: string;
   /** Optional LCP image preload: { src, srcset } so the image is discoverable from HTML immediately. */
   lcpPreload?: { src: string; srcset: string };
 }
@@ -15,15 +17,14 @@ const {
   description = 'Senior Engineering Manager with expertise in leading cross-functional teams, project delivery, and fostering innovation. View my professional experience and contact information.',
   canonical = 'https://www.garbereder.com',
   keywords = 'Engineering Manager, Project Management, Team Leadership, Software Development, Innovation',
-  extraFontUrl,
+  extraFontCssVariable,
   lcpPreload,
 } = Astro.props;
 ---
 
 <head>
   <meta charset="utf-8" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <Font cssVariable="--font-quicksand" preload />
 
   {
     lcpPreload && (
@@ -56,12 +57,7 @@ const {
   <link rel="canonical" href={canonical} />
   <link rel="icon" type="image/x-icon" href="favicon.ico" />
 
-  <link
-    rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Quicksand&display=swap"
-  />
-
-  {extraFontUrl && <link rel="stylesheet" href={extraFontUrl} />}
+  {extraFontCssVariable && <Font cssVariable={extraFontCssVariable} />}
 
   <script>
     document.querySelector('html')?.classList.remove('nojs');

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -8,14 +8,20 @@ interface Props {
   description?: string;
   canonical?: string;
   keywords?: string;
-  /** Optional extra font stylesheet URL (injected into head). */
-  extraFontUrl?: string;
+  /** Optional extra font CSS variable (e.g. '--font-fraunces') injected into head. */
+  extraFontCssVariable?: string;
   /** Optional LCP image preload for the head. */
   lcpPreload?: { src: string; srcset: string };
 }
 
-const { title, description, canonical, keywords, extraFontUrl, lcpPreload } =
-  Astro.props;
+const {
+  title,
+  description,
+  canonical,
+  keywords,
+  extraFontCssVariable,
+  lcpPreload,
+} = Astro.props;
 ---
 
 <!doctype html>
@@ -25,7 +31,7 @@ const { title, description, canonical, keywords, extraFontUrl, lcpPreload } =
     description={description}
     canonical={canonical}
     keywords={keywords}
-    extraFontUrl={extraFontUrl}
+    extraFontCssVariable={extraFontCssVariable}
     lcpPreload={lcpPreload}
   />
   <StructuredData />

--- a/src/pages/start-at-05.astro
+++ b/src/pages/start-at-05.astro
@@ -1,9 +1,6 @@
 ---
 import Main from '../layouts/main.astro';
 
-const FRAUNCES_URL =
-  'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,600;1,9..144,400&display=swap';
-
 const sectionClass = 'py-8 border-t border-slate-700';
 const summarySectionClass = 'pt-8 pb-8';
 const containerClass = 'max-w-3xl mx-auto px-4 sm:px-6';
@@ -19,7 +16,7 @@ const slotCards = [
   description="Start meetings five minutes after the hour. Fewer late arrivals, calmer transitions, built-in breaks. A simple meeting policy that works."
   canonical="https://start-at-05.com/"
   keywords="meeting policy, meeting times, Start at :05, scheduling, productivity, calendar, back-to-back meetings"
-  extraFontUrl={FRAUNCES_URL}
+  extraFontCssVariable="--font-fraunces"
 >
   <div class="start-at-05 min-h-screen flex flex-col">
     <a

--- a/src/styles/start-at-05.scss
+++ b/src/styles/start-at-05.scss
@@ -8,7 +8,6 @@ $start-at-05-font-sans:
   'Segoe UI',
   Roboto,
   sans-serif;
-$start-at-05-font-serif: 'Fraunces', Georgia, serif;
 
 .start-at-05 {
   font-family: $start-at-05-font-sans;
@@ -25,7 +24,7 @@ $start-at-05-font-serif: 'Fraunces', Georgia, serif;
   .start-at-05-h1,
   .start-at-05-h2,
   .start-at-05-h3 {
-    font-family: $start-at-05-font-serif;
+    font-family: var(--font-fraunces);
   }
 
   .start-at-05-h1 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@ export default {
   theme: {
     extend: {},
     fontFamily: {
-      sans: ['Quicksand', 'ui-sans-serif', 'system-ui'],
+      sans: ['var(--font-quicksand)', 'ui-sans-serif', 'system-ui'],
     },
   },
   variants: {},


### PR DESCRIPTION
Replace manual Google Fonts <link> tags with Astro's built-in Fonts API. Fonts are now downloaded, cached, and served locally with auto-generated fallbacks. Removes preconnect/stylesheet links from head.astro and the hardcoded FRAUNCES_URL constant.