### PR TITLE
Chore(ci): upgrade actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/cursor-code-review.yml
+++ b/.github/workflows/cursor-code-review.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,11 +40,11 @@ jobs:
     continue-on-error: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -73,11 +73,11 @@ jobs:
     continue-on-error: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -106,9 +106,9 @@ jobs:
     needs: audit
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -31,11 +31,11 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbereder.com",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbereder.com",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "hasInstallScript": true,
       "devDependencies": {
         "@astrojs/preact": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbereder.com",
   "type": "module",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout@v4` → `@v5` in all 3 workflows
- Upgrades `actions/setup-node@v4` → `@v5` in `static.yml` and `version-bump.yml`
- Eliminates Node.js 20 deprecation warning — v5 targets Node.js 24 natively

## Test plan
- [ ] CI runs without Node.js 20 deprecation warnings
- [ ] All jobs (audit, build, test, deploy, version-bump, code-review) complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)