### PR TITLE
Chore(ci): upgrade artifact actions to Node.js 24 native versions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build website
         run: npm run build
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -132,13 +132,13 @@ jobs:
         env:
           CYPRESS_COVERAGE: true
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/
           if-no-files-found: warn
       - name: Upload test screenshots on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-screenshots
@@ -154,14 +154,14 @@ jobs:
     needs: [build, test] # Requires both build artifact and passing tests
     if: github.ref == 'refs/heads/main' # Only deploy from main branch
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist/'
       - name: Deploy to GitHub Pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbereder.com",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbereder.com",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "hasInstallScript": true,
       "devDependencies": {
         "@astrojs/preact": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbereder.com",
   "type": "module",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Summary
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `actions/upload-pages-artifact` v3 → v5

Fixes deprecation warning: _Node.js 20 is deprecated — actions target Node.js 20 but are being forced to run on Node.js 24._

All upgraded versions natively target Node.js 24, removing the need for the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround (kept for safety).

## Test plan
- [ ] CI passes without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)