### PR TITLE
Upgrade GitHub Pages actions to Node.js 24

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -149,11 +149,11 @@ jobs:
           name: dist
           path: dist/
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: './dist/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbereder.com",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbereder.com",
-      "version": "1.0.55",
+      "version": "1.0.56",
       "hasInstallScript": true,
       "devDependencies": {
         "@astrojs/preact": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbereder.com",
   "type": "module",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "packageManager": "npm@11.6.2",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Summary
- Upgrade `actions/configure-pages` from v5 to v6 (native `node24`)
- Upgrade `actions/deploy-pages` from v4 to v5 (native `node24`)

This removes the deploy job deprecation warning about Node.js 20 actions being forced onto Node.js 24.

## Test plan
- [ ] CI `audit`, `build`, and `test` jobs pass
- [ ] Deploy job on `main` completes without Node 20 deprecation warnings


Made with [Cursor](https://cursor.com)