### PR TITLE
test(visual): raise diff threshold to 4% to absorb render flake

### DIFF
--- a/cypress/e2e/visual/index.visual.cy.js
+++ b/cypress/e2e/visual/index.visual.cy.js
@@ -1,6 +1,9 @@
 /// <reference types="cypress" />
 
-const THRESHOLD = 0.01;
+// 4% tolerance: text-heavy pages show ~2% run-to-run sub-pixel/font-render
+// variance even with fonts.ready awaited. Real layout regressions are far
+// larger (the astro 7 whitespace collapse was 8%).
+const THRESHOLD = 0.04;
 
 const viewports = [
   { name: 'desktop', width: 1280, height: 800 },

--- a/cypress/e2e/visual/start-at-05.visual.cy.js
+++ b/cypress/e2e/visual/start-at-05.visual.cy.js
@@ -1,6 +1,9 @@
 /// <reference types="cypress" />
 
-const THRESHOLD = 0.01;
+// 4% tolerance: text-heavy pages show ~2% run-to-run sub-pixel/font-render
+// variance even with fonts.ready awaited. Real layout regressions are far
+// larger (the astro 7 whitespace collapse was 8%).
+const THRESHOLD = 0.04;
 
 const viewports = [
   { name: 'desktop', width: 1280, height: 800 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbereder.com",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbereder.com",
-      "version": "1.0.61",
+      "version": "1.0.62",
       "hasInstallScript": true,
       "devDependencies": {
         "@astrojs/preact": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbereder.com",
   "type": "module",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "packageManager": "npm@11.6.2",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
The visual regression specs flake at the 1% pixel threshold: text-heavy pages show ~2% run-to-run sub-pixel/font-rendering variance on CI even after awaiting `fonts.ready`. This intermittently failed the deploy-gating `test` job on main after the astro 7 merge (#385).

Raise `THRESHOLD` from 0.01 → 0.04 in both visual specs. Still well below the 8% diff of the astro 7 whitespace-collapse regression this suite exists to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)